### PR TITLE
Support MongoDB authentication (optionally)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,5 @@ djigger.settings
 *lastsession.xml
 agent.jar
 collector.jar
+.idea/
+*.iml

--- a/client-ui/src/main/java/io/djigger/ui/Session.java
+++ b/client-ui/src/main/java/io/djigger/ui/Session.java
@@ -265,7 +265,7 @@ public class Session extends JPanel implements FacadeListener, Closeable {
     			}catch(NumberFormatException e){
     				port = 27017;
     			}
-    			storeClient.connect(hostname, port);
+    			storeClient.connect(hostname, port, params.get(SessionParameter.USERNAME), params.get(SessionParameter.PASSWORD));
     		} else if (getSessionType()==SessionType.AGENT_CAPTURE) {
     			final File file = new File(config.getParameters().get(SessionParameter.FILE));
     			MonitoredExecution execution = new MonitoredExecution(main.getFrame(), "Opening session... Please wait.", new MonitoredExecutionRunnable() {

--- a/collector/src/main/java/io/djigger/collector/server/Server.java
+++ b/collector/src/main/java/io/djigger/collector/server/Server.java
@@ -127,13 +127,16 @@ public class Server {
 		
 		try {
 			MongoDBParameters connectionParams = config.getDb();
+
+			int port = 27017;
+
 			if(connectionParams.getPort()!=null) {
-				Integer port = Integer.parseInt(connectionParams.getPort());
-				mongodbConnection.connect(connectionParams.getHost(), port);				
-			} else {
-				mongodbConnection.connect(connectionParams.getHost());			
+				port = Integer.parseInt(connectionParams.getPort());
 			}
-			
+
+			mongodbConnection.connect(connectionParams.getHost(), port, connectionParams.getUser(), connectionParams.getPassword());
+
+
 			Long ttl = config.getDataTTL();
 			
 			threadInfoAccessor = new ThreadInfoAccessorImpl(mongodbConnection.getDb());

--- a/collector/src/main/java/io/djigger/collector/server/conf/MongoDBParameters.java
+++ b/collector/src/main/java/io/djigger/collector/server/conf/MongoDBParameters.java
@@ -28,9 +28,15 @@ public class MongoDBParameters {
 	
 	@XStreamAsAttribute
 	String port;
-	
+
 	@XStreamAsAttribute
 	String collection;
+
+	@XStreamAsAttribute
+	String user;
+
+	@XStreamAsAttribute
+	String password;
 
 	public String getHost() {
 		return host;
@@ -40,9 +46,7 @@ public class MongoDBParameters {
 		this.host = host;
 	}
 
-	public String getPort() {
-		return port;
-	}
+	public String getPort() { return port; }
 
 	public void setPort(String port) {
 		this.port = port;
@@ -54,6 +58,22 @@ public class MongoDBParameters {
 
 	public void setCollection(String collection) {
 		this.collection = collection;
+	}
+
+	public String getUser() {
+		return user;
+	}
+
+	public void setUser(String user) {
+		this.user= user;
+	}
+
+	public String getPassword() {
+		return password;
+	}
+
+	public void setPassword(String password) {
+		this.password = password;
 	}
 
 }

--- a/commons/src/main/java/io/djigger/collector/accessors/MongoConnection.java
+++ b/commons/src/main/java/io/djigger/collector/accessors/MongoConnection.java
@@ -3,8 +3,12 @@ package io.djigger.collector.accessors;
 import com.mongodb.MongoClient;
 import com.mongodb.MongoClientOptions;
 import com.mongodb.MongoClientOptions.Builder;
+import com.mongodb.MongoCredential;
 import com.mongodb.ServerAddress;
 import com.mongodb.client.MongoDatabase;
+
+import java.util.ArrayList;
+import java.util.List;
 
 public class MongoConnection {
 
@@ -12,22 +16,25 @@ public class MongoConnection {
 	
 	private MongoDatabase db;
 	
-	public MongoDatabase connect(String host, int port) {
-		Builder o = MongoClientOptions.builder().serverSelectionTimeout(3000);  
-		mongoClient = new MongoClient(new ServerAddress(host,port), o.build());
+	public MongoDatabase connect(String host, int port, String user, String password) {
+		Builder o = MongoClientOptions.builder().serverSelectionTimeout(3000);
+
+		String databaseName = "djigger";
+
+		List<MongoCredential> credentials = new ArrayList<>();
+		if (user != null && password != null && !user.trim().isEmpty() && !password.trim().isEmpty()) {
+			credentials.add(MongoCredential.createCredential(user, databaseName, password.toCharArray()));
+		}
+
+		mongoClient = new MongoClient(new ServerAddress(host,port), credentials, o.build());
 		
 		// call this method to check if the connection succeeded as the mongo client lazy loads the connection 
 		mongoClient.getAddress();
 		
-		db = mongoClient.getDatabase("djigger");
+		db = mongoClient.getDatabase(databaseName);
 		return db;
 	}
-	
-	public MongoDatabase connect(String host) {
-		return connect(host, 27017);
-	}
-	
-	
+
 	public MongoDatabase getDb() {
 		return db;
 	}

--- a/commons/src/main/java/io/djigger/db/client/StoreClient.java
+++ b/commons/src/main/java/io/djigger/db/client/StoreClient.java
@@ -33,9 +33,9 @@ public class StoreClient {
 	
 	MetricAccessor metricAccessor;
 	
-	public void connect(String host, int port) throws Exception {
+	public void connect(String host, int port, String user, String password) throws Exception {
 		MongoConnection connection = new MongoConnection();
-		connection.connect(host, port);
+		connection.connect(host, port, user, password);
 		threadInfoAccessor = new ThreadInfoAccessorImpl(connection.getDb());
 		instrumentationAccessor = new InstrumentationEventAccessor(connection.getDb());
 		metricAccessor = new MetricAccessor(connection.getDb());

--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -8,7 +8,7 @@
 
 	<properties>
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-		<java.home>C:\Program Files\Java\jdk1.8.0_101</java.home>
+		<java.home>C:\Program Files\Java\jdk1.8.0_131</java.home>
 	</properties>
 	
 	<repositories>


### PR DESCRIPTION
This pull requests adds support for (optionally) using user credentials when connecting to a MongoDB running with the --auth option.

It adds support for two optional attributes (user and password) to the Collector.xml, e.g.:
`
<db host="192.168.56.102" user="collector" password="collector123"/>
`

Additionally, the client UI now considers the username and password fields when connecting to the DB. Unfortunately, if credentials are required but missing, you'll only get an exception once you actually perform a query (i.e., the UI still says "connection succeeded"). Maybe there's an easy way to fix this, but I'm not sure how.

Sample MongoDB configuration in a nutshell:
```
# start mongod without authentication, then:
# ./mongo
use admin
db.createUser({user:"admin",pwd:"admin123",roles:[{role:"userAdminAnyDatabase",db:"admin"}]})

# stop mongod, start with --auth parameter, then:
# ./mongo -u admin -p admin123 --authenticationDatabase admin
use djigger
db.createUser({user:"collector",pwd:"collector123",roles:[{role:"dbOwner",db:"djigger"}]})
db.createUser({user:"client",pwd:"client123",roles:[{role:"read",db:"djigger"}]})
```

Comments or amendments are of course welcome :-)

