### PR TITLE
Fix startup with defined JAVA_HOME, allow local override

### DIFF
--- a/distribution/template/bin/startClient.sh
+++ b/distribution/template/bin/startClient.sh
@@ -1,18 +1,28 @@
 #!/bin/bash
-
-JAVA_PATH=""
-#JAVA_PATH="/usr/sbin/jre1.8.0_77/bin/"
-
 execdir="$(readlink -f `dirname ${BASH_SOURCE[0]}`)"
+
+# If you don't have `java` in your $PATH or you want to use a different JDK, either export
+# JAVA_HOME in your profile or adjust and uncomment the definition below
+#
+#DJIGGER_JAVA_HOME="/usr/lib/jdk1.8.0_77"
 
 DJIGGER_HOME="${DJIGGER_HOME:-$(dirname ${execdir})}"
 DJIGGER_CONFDIR="${DJIGGER_CONFDIR:-${DJIGGER_HOME}/conf}"
 DJIGGER_LIBDIR="${DJIGGER_LIBDIR:-${DJIGGER_HOME}/lib}"
 
-START_OPTS=()
-START_OPTS+=("-Dlogback.configurationFile=${DJIGGER_CONFDIR}/logback-client.xml")
-START_OPTS+=("${JAVA_OPTS}")
+# Required JVM arguments for djigger
+DJIGGER_OPTS=("-Dlogback.configurationFile=${DJIGGER_CONFDIR}/logback-client.xml")
+
+# Custom JVM arguments can be set by exporting JAVA_OPTS in your profile
+
+if [ -n "${JAVA_HOME:-${DJIGGER_JAVA_HOME}}" ]; then
+    RUNJAVA="${JAVA_HOME:-${DJIGGER_JAVA_HOME}}/bin/java"
+    JDK_LIBS="${JAVA_HOME:-${DJIGGER_JAVA_HOME}}/lib"
+else
+    RUNJAVA="java"
+fi
 
 cd "${DJIGGER_HOME}" \
-    && exec "${JAVA_HOME}java" ${START_OPTS[@]} -cp "${DJIGGER_LIBDIR}/*:${JAVA_PATH}/../lib/tools.jar" io.djigger.ui.MainFrame \
+    && exec "${RUNJAVA}" ${DJIGGER_OPTS[@]} -cp "${DJIGGER_LIBDIR}/*:${JDK_LIBS}/tools.jar"
+         ${JAVA_OPTS} io.djigger.ui.MainFrame \
     || echo "Error: Invalid DJIGGER_HOME"

--- a/distribution/template/bin/startClient.sh
+++ b/distribution/template/bin/startClient.sh
@@ -13,16 +13,15 @@ DJIGGER_LIBDIR="${DJIGGER_LIBDIR:-${DJIGGER_HOME}/lib}"
 # Required JVM arguments for djigger
 DJIGGER_OPTS=("-Dlogback.configurationFile=${DJIGGER_CONFDIR}/logback-client.xml")
 
-# Custom JVM arguments can be set by exporting JAVA_OPTS in your profile
-
+# For the direct attach feature the JDK home must be defined so we can properly add tools.jar
+# to the classpath
 if [ -n "${JAVA_HOME:-${DJIGGER_JAVA_HOME}}" ]; then
-    RUNJAVA="${JAVA_HOME:-${DJIGGER_JAVA_HOME}}/bin/java"
-    JDK_LIBS="${JAVA_HOME:-${DJIGGER_JAVA_HOME}}/lib"
-else
-    RUNJAVA="java"
+    JAVA="${JAVA_HOME:-${DJIGGER_JAVA_HOME}}/bin/java"
+    TOOLS_JAR=":${JAVA_HOME:-${DJIGGER_JAVA_HOME}}/lib/tools.jar"
 fi
 
+# Custom JVM arguments can be set by exporting JAVA_OPTS in your profile
 cd "${DJIGGER_HOME}" \
-    && exec "${RUNJAVA}" ${DJIGGER_OPTS[@]} -cp "${DJIGGER_LIBDIR}/*:${JDK_LIBS}/tools.jar"
+    && exec "${JAVA:-java}" ${DJIGGER_OPTS[@]} -cp "${DJIGGER_LIBDIR}/*${TOOLS_JAR}" \
          ${JAVA_OPTS} io.djigger.ui.MainFrame \
     || echo "Error: Invalid DJIGGER_HOME"

--- a/distribution/template/bin/startCollector.sh
+++ b/distribution/template/bin/startCollector.sh
@@ -14,15 +14,15 @@ DJIGGER_LIBDIR="${DJIGGER_LIBDIR:-${DJIGGER_HOME}/lib}"
 DJIGGER_OPTS+=("-DcollectorConfig=${DJIGGER_CONFDIR}/Collector.xml")
 DJIGGER_OPTS+=("-Dlogback.configurationFile=${DJIGGER_CONFDIR}/logback-collector.xml")
 
-# Custom JVM arguments can be set by exporting JAVA_OPTS in your profile
-
+# For the direct attach feature the JDK home must be defined so we can properly add tools.jar
+# to the classpath
 if [ -n "${JAVA_HOME:-${DJIGGER_JAVA_HOME}}" ]; then
-    RUNJAVA="${JAVA_HOME:-${DJIGGER_JAVA_HOME}}/bin/java"
-else
-    RUNJAVA="java"
+    JAVA="${JAVA_HOME:-${DJIGGER_JAVA_HOME}}/bin/java"
+    TOOLS_JAR=":${JAVA_HOME:-${DJIGGER_JAVA_HOME}}/lib/tools.jar"
 fi
 
+# Custom JVM arguments can be set by exporting JAVA_OPTS in your profile
 cd "${DJIGGER_HOME}" \
-    && exec "${RUNJAVA}" ${DJIGGER_OPTS[@]} -cp "${DJIGGER_LIBDIR}/*" \
+    && exec "${JAVA:-java}" ${DJIGGER_OPTS[@]} -cp "${DJIGGER_LIBDIR}/*${TOOLS_JAR}" \
          ${JAVA_OPTS} io.djigger.collector.server.Server \
     || echo "Error: Invalid DJIGGER_HOME"

--- a/distribution/template/bin/startCollector.sh
+++ b/distribution/template/bin/startCollector.sh
@@ -1,19 +1,28 @@
 #!/bin/bash
-
-JAVA_PATH=""
-#JAVA_PATH="/usr/sbin/jre1.8.0_77/bin/"
-
 execdir="$(readlink -f `dirname ${BASH_SOURCE[0]}`)"
+
+# If you don't have `java` in your $PATH or you want to use a different JDK, either export
+# JAVA_HOME in your profile or adjust and uncomment the definition below
+#
+#DJIGGER_JAVA_HOME="/usr/lib/jdk1.8.0_77"
 
 DJIGGER_HOME="${DJIGGER_HOME:-$(dirname ${execdir})}"
 DJIGGER_CONFDIR="${DJIGGER_CONFDIR:-${DJIGGER_HOME}/conf}"
 DJIGGER_LIBDIR="${DJIGGER_LIBDIR:-${DJIGGER_HOME}/lib}"
 
-START_OPTS=()
-START_OPTS+=("-DcollectorConfig=${DJIGGER_CONFDIR}/Collector.xml")
-START_OPTS+=("-Dlogback.configurationFile=${DJIGGER_CONFDIR}/logback-collector.xml")
-START_OPTS+=("${JAVA_OPTS}")
+# Required JVM arguments for djigger
+DJIGGER_OPTS+=("-DcollectorConfig=${DJIGGER_CONFDIR}/Collector.xml")
+DJIGGER_OPTS+=("-Dlogback.configurationFile=${DJIGGER_CONFDIR}/logback-collector.xml")
+
+# Custom JVM arguments can be set by exporting JAVA_OPTS in your profile
+
+if [ -n "${JAVA_HOME:-${DJIGGER_JAVA_HOME}}" ]; then
+    RUNJAVA="${JAVA_HOME:-${DJIGGER_JAVA_HOME}}/bin/java"
+else
+    RUNJAVA="java"
+fi
 
 cd "${DJIGGER_HOME}" \
-    && exec "${JAVA_HOME}java" ${START_OPTS[@]} -cp "${DJIGGER_LIBDIR}/*" io.djigger.collector.server.Server \
+    && exec "${RUNJAVA}" ${DJIGGER_OPTS[@]} -cp "${DJIGGER_LIBDIR}/*" \
+         ${JAVA_OPTS} io.djigger.collector.server.Server \
     || echo "Error: Invalid DJIGGER_HOME"


### PR DESCRIPTION
Ok, the `startCollector.sh` is the easiest. By convention the `JAVA_HOME` environment variable would allow a user to specify the JVM being used and can point to a JDK (or sometimes JRE) installation directory. No matter if JRE or JDK, `$JAVA_HOME/bin/java` must be the JVM which is executed when `$JAVA_HOME` is defined outside the startup script.

If you like to have your custom Java installation being defined in the startup script, as this might be easier for you, I added a `DJIGGER_JAVA_HOME` variable. I still wouldn't break with the widely used convention to define the Java home instead of the `bin/` directory as you did.

In the default case, `java` is used from the `$PATH` as before.

If someone would like to override the "hardcoded" `-D...` startup arguments, this can be done by redefining them in `$JAVA_OPTS` which by convention is used to pass custom JVM arguments.

In the long term it obviously would be preferable to read the required configurations from `$DJIGGER_CONFDIR` by default without the need to specify them as startup arguments.