### PR TITLE
Add proper init scripts and document system setup

### DIFF
--- a/distribution/template/contrib/INSTALL.md
+++ b/distribution/template/contrib/INSTALL.md
@@ -1,0 +1,111 @@
+# Setup Djigger Startup on Linux
+
+This directory contains a number of helper scripts to properly integrate the
+Djigger Collector and Client startup on a server or a desktop environment.
+
+## djigger Collector
+
+If you want to automatically startup the djigger collector service on system
+boot it has to be integrated into the init-system. On traditional Linux
+distributions such as RHEL 6/CentOS 6 follow the SYSV init approach. More
+modern distributions such as RHEL 7/CentOS 7 and Ubuntu 16.04 are using the
+`systemd` init system for which the corresponding instructions below should
+be used. 
+
+### SYSV Init
+
+**Service Configuration**
+
+Copy the service configuration file to the `/etc/sysconfig` directory and
+change its ownership to root:
+
+    # cp contrib/djigger-collector.sysconfig /etc/sysconfig/djigger-collector
+    # chown root:root /etc/sysconfig/djigger-collector
+    # chmod 0644 /etc/sysconfig/djigger-collector
+
+In this configuration file, you can set various variables which influence the
+service startup:
+
+* `DJIGGER_HOME` (defaults to `/opt/denkbar/djigger`) Path to your djigger
+  installation.
+* `DJIGGER_USER` (defaults to `djigger`): User account which will run the
+  collector service. You might need to create the user account and give it
+  access to the djigger installation. E.g.
+  
+      # useradd -r -d /opt/denkbar/djigger djigger
+      # chown -R djigger:djigger /opt/denkbar/djigger
+  
+* `DJIGGER_OUTFILE` (defaults to `/opt/denkbar/djigger/log/collector.out`):
+  Logfile where stdout and stderr of the collector process are stored. Set
+  this to `/dev/null` if those messages shouldn't be stored.
+  
+* `JAVA_HOME` (unset by default): Root directory of your Java Development Kit
+  installation. You must set this if you want to use the direct process attach
+  feature of the collector service.
+  
+* `JAVA_ARGS` (unset by default): Custom Java VM startup arguments. Here you
+  can e.g. restrict the heap size via `-Xmx512m`
+  
+**Init Script**
+
+Copy the init script to the `/etc/init.d` directory, change its ownership to
+root and make it executable:
+
+     # cp contrib/djigger-collector.initd /etc/init.d/djigger-collector
+     # chown root:root /etc/init.d/djigger-collector
+     # chmod 0755 /etc/init.d/djigger-collector
+     
+To enable autostart on system boot, register the service via `chkconfig`:
+
+    # chkconfig djigger-collector on
+    
+To manually start/stop/restart the collector service run:
+
+    # service djigger-collector start
+    # service djigger-collector stop
+    # service djigger-collector restart
+
+Check the status of the collector service:
+
+    # service djigger-collector status
+
+## systemd
+
+On a Linux system running `systemd` simply copy the service file into the
+system configuration directory and change the ownership to root:
+
+    # cp contrib/djigger-collector.service /etc/systemd/system/djigger-collector.service
+    # chown root:root /etc/systemd/system/djigger-collector.service
+    # chmod 0644 /etc/systemd/system/djigger-collector.service
+    
+Adjust the content according to your djigger setup:
+
+* `Exec` (defaults to `/opt/denkbar/djigger/bin/startCollector.sh`): Command
+  which is executed when starting the service. Adjust this path to your djigger
+  installation.
+* `User`/`Group` (defaults to `djigger`): User account which will run the
+  collector service. You might need to create the user account and give it
+  access to the djigger installation. E.g.
+                                            
+      # useradd -r -d /opt/denkbar/djigger djigger
+      # chown -R djigger:djigger /opt/denkbar/djigger
+ 
+* `Environment` (unset by default): Set any environment variable for the
+  collector service. E.g. you must define `JAVA_HOME` if you want to use the
+  direct process attach feature of the collector service as following:
+  
+      Environment=JAVA_HOME=/usr/lib/jvm/java-1.8.0-openjdk
+      
+To enable autostart on system boot, enable the service via `systemctl`:
+
+    # systemctl enable djigger-collector
+    
+To start/stop/restart the collector service run:
+
+    # systemctl start djigger-collector
+    # systemctl stop djigger-collector
+    # systemctl restart djigger-collector
+    
+Check the status of the collector service:
+
+    # systemctl status djigger-collector                                        

--- a/distribution/template/contrib/INSTALL.md
+++ b/distribution/template/contrib/INSTALL.md
@@ -12,6 +12,71 @@ modern distributions such as RHEL 7/CentOS 7 and Ubuntu 16.04 are using the
 `systemd` init system for which the corresponding instructions below should
 be used. 
 
+### systemd
+
+The only file required for the `systemd` setup is the
+`contrib/djigger-collector.service` is an example for a systemd
+[service unit](https://www.freedesktop.org/software/systemd/man/systemd.service.html).
+`systemd` allows a service to be setup and controlled in a user session what
+might be useful on a developer machine. In a production setup where only one
+collector is required which is then managed a with privileged admin account,
+the collector service can be setup as regular `systemd` service.
+
+#### Production Setup
+
+Setup the collector daemon as regular `systemd` service. The following tasks
+prefixed with a `#` must be done with root permissions. Copy the service file
+into the system configuration directory and change the ownership to root:
+
+    # cp contrib/djigger-collector.service /etc/systemd/system/djigger-collector.service
+    # chown root:root /etc/systemd/system/djigger-collector.service
+    # chmod 0644 /etc/systemd/system/djigger-collector.service
+
+**Service Configuration**
+
+Adjust the content of `/etc/systemd/system/djigger-collector.service` according
+to your djigger setup:
+
+* `Exec` (defaults to `/opt/denkbar/djigger/bin/startCollector.sh`): Command
+  which is executed when starting the service. Adjust this path to your djigger
+  installation.
+* `User`/`Group` (defaults to `djigger`): User account which will run the
+  collector service. You might need to create the user account and give it
+  access to the djigger installation. E.g.
+
+      # useradd -r -d /opt/denkbar/djigger djigger
+      # chown -R djigger:djigger /opt/denkbar/djigger
+
+* `Environment` (unset by default): Set any environment variable for the
+  collector service. E.g. you must define `JAVA_HOME` if you want to use the
+  direct process attach feature of the collector service as following:
+
+      Environment=JAVA_HOME=/usr/lib/jvm/java-1.8.0-openjdk
+
+  Optionally additional environment variables accepted by the collector startup
+  script can be added. E.g. to define additional startup arguments, you can
+  set:
+
+      Environment=JAVA_OPTS=-Xmx512m
+
+**Autostart**
+
+To enable autostart on system boot, enable the service via `systemctl`:
+
+    # systemctl enable djigger-collector
+
+**Start/Stop Service**
+
+To start/stop/restart the collector service run:
+
+    # systemctl start djigger-collector
+    # systemctl stop djigger-collector
+    # systemctl restart djigger-collector
+
+Check the status of the collector service:
+
+    # systemctl status djigger-collector
+
 ### SYSV Init
 
 **Service Configuration**
@@ -43,7 +108,7 @@ service startup:
   installation. You must set this if you want to use the direct process attach
   feature of the collector service.
   
-* `JAVA_ARGS` (unset by default): Custom Java VM startup arguments. Here you
+* `JAVA_OPTS` (unset by default): Custom Java VM startup arguments. Here you
   can e.g. restrict the heap size via `-Xmx512m`
   
 **Init Script**
@@ -68,44 +133,3 @@ To manually start/stop/restart the collector service run:
 Check the status of the collector service:
 
     # service djigger-collector status
-
-## systemd
-
-On a Linux system running `systemd` simply copy the service file into the
-system configuration directory and change the ownership to root:
-
-    # cp contrib/djigger-collector.service /etc/systemd/system/djigger-collector.service
-    # chown root:root /etc/systemd/system/djigger-collector.service
-    # chmod 0644 /etc/systemd/system/djigger-collector.service
-    
-Adjust the content according to your djigger setup:
-
-* `Exec` (defaults to `/opt/denkbar/djigger/bin/startCollector.sh`): Command
-  which is executed when starting the service. Adjust this path to your djigger
-  installation.
-* `User`/`Group` (defaults to `djigger`): User account which will run the
-  collector service. You might need to create the user account and give it
-  access to the djigger installation. E.g.
-                                            
-      # useradd -r -d /opt/denkbar/djigger djigger
-      # chown -R djigger:djigger /opt/denkbar/djigger
- 
-* `Environment` (unset by default): Set any environment variable for the
-  collector service. E.g. you must define `JAVA_HOME` if you want to use the
-  direct process attach feature of the collector service as following:
-  
-      Environment=JAVA_HOME=/usr/lib/jvm/java-1.8.0-openjdk
-      
-To enable autostart on system boot, enable the service via `systemctl`:
-
-    # systemctl enable djigger-collector
-    
-To start/stop/restart the collector service run:
-
-    # systemctl start djigger-collector
-    # systemctl stop djigger-collector
-    # systemctl restart djigger-collector
-    
-Check the status of the collector service:
-
-    # systemctl status djigger-collector                                        

--- a/distribution/template/contrib/INSTALL.md
+++ b/distribution/template/contrib/INSTALL.md
@@ -63,19 +63,71 @@ to your djigger setup:
 
 To enable autostart on system boot, enable the service via `systemctl`:
 
-    # systemctl enable djigger-collector
+    # systemctl enable djigger-collector.service
 
 **Start/Stop Service**
 
 To start/stop/restart the collector service run:
 
-    # systemctl start djigger-collector
-    # systemctl stop djigger-collector
-    # systemctl restart djigger-collector
+    # systemctl start djigger-collector.service
+    # systemctl stop djigger-collector.service
+    # systemctl restart djigger-collector.service
 
 Check the status of the collector service:
 
-    # systemctl status djigger-collector
+    # systemctl status djigger-collector.service
+
+**Logging**
+
+The stdout/stderr on a host running `systemd` is usually availble via
+"journal". To check the messages run:
+
+    # journalctl -u djigger-collector.service
+
+#### Developer Setup
+
+**Ad-Hoc Startup**
+
+It's possible to run the djigger collector in an ad-hoc mode by simply starting
+it with the `bin/startCollector.sh` script. In case you need some customization
+the start script will read the following variables from your shell environment:
+
+* `JAVA_HOME`: Root directory of your Java Development Kit installation. This
+  must be set if you want to use the direct process attach feature of the
+  collector service.
+
+* `JAVA_OPTS`:  Custom Java VM startup arguments.
+
+* `DJIGGER_HOME`: This is automatically detected if unset.
+
+* `DJIGGER_CONFDIR`: Configuration directory where `Collector.xml`,
+  `Connections.csv` and such are read.
+
+* `DJIGGER_LIBDIR`: Classpath configuration pointing to the collector
+  libraries.
+
+**systemd User Session**
+
+`systemd` supports the management of services within a user session. This
+allows a developer to run its individual copy of the collector daemon and still
+leverage all the systemd amenities. Run the following commands prefixed with a
+`$` with your personal user account:
+
+    $ mkdir -p ~/.config/systemd/user
+    $ cp contrib/djigger-collector.service ~/.config/systemd/user/djigger-collector.service
+    $ chmod 0644 ~/.config/systemd/user/djigger-collector.service
+
+Adjust the `User=` and `Group=` settings in `~/.config/systemd/user/djigger-collector.service`
+with your Linux account name and adjust the `ExecStart=` configuration with the
+path to your djigger copy and make sure that your user account has write access
+to it. For more details to the remaining configuration options check the
+corresponding section in the "Production Setup" chapter.
+
+The `systemctl` commands described above are also valid for the user session
+mode of `systemd`. They only have to be extended with the `--user` argument.
+E.g. to start your personal djigger collector, run:
+
+    $ systemctl --user start djigger-collector.service
 
 ### SYSV Init
 
@@ -105,8 +157,8 @@ service startup:
   this to `/dev/null` if those messages shouldn't be stored.
   
 * `JAVA_HOME` (unset by default): Root directory of your Java Development Kit
-  installation. You must set this if you want to use the direct process attach
-  feature of the collector service.
+  installation. This must be defined if you want to use the direct process
+  attach feature of the collector service.
   
 * `JAVA_OPTS` (unset by default): Custom Java VM startup arguments. Here you
   can e.g. restrict the heap size via `-Xmx512m`
@@ -119,11 +171,15 @@ root and make it executable:
      # cp contrib/djigger-collector.initd /etc/init.d/djigger-collector
      # chown root:root /etc/init.d/djigger-collector
      # chmod 0755 /etc/init.d/djigger-collector
-     
+
+**Autostart**
+
 To enable autostart on system boot, register the service via `chkconfig`:
 
     # chkconfig djigger-collector on
-    
+
+**Start/Stop Service**
+
 To manually start/stop/restart the collector service run:
 
     # service djigger-collector start

--- a/distribution/template/contrib/djigger-collector.initd
+++ b/distribution/template/contrib/djigger-collector.initd
@@ -1,0 +1,59 @@
+#!/bin/bash
+#
+# djigger-collector - Startup script for the djigger Collector
+#
+# chkconfig: - 91 19
+#
+### BEGIN INIT INFO
+# Provides: djigger-collector
+# Required-Start: $mongod $time
+# Should-Start:
+# Default-Start: 3 4 5
+# Short-Description: djigger Collector
+# Description: djigger Collector for storing Java performance data in a MongoDB
+### END INIT INFO
+
+## Source function library
+. /etc/init.d/functions
+
+if [ ! -f /etc/sysconfig/djigger-collector ]; then
+    exit 6
+fi
+
+. /etc/sysconfig/djigger-collector
+
+collector_pid() {
+    pgrep -u "${DJIGGER_USER}" -f io.djigger.collector.server.Server
+}
+
+case "$1" in
+    start)
+        echo -n "Starting djigger Collector: "
+        su - ${DJIGGER_USER} -c "${DJIGGER_HOME}/bin/startCollector.sh >>${DJIGGER_OUTFILE} 2>&1 &"
+        sleep 1
+        test -n "$(collector_pid)" && success || failure
+        echo
+    ;;
+    stop)
+        echo -n "Stopping djigger Collector: "
+        kill -15 $(collector_pid)
+        sleep 5
+        test -z "$(collector_pid)" && success || failure
+        echo
+    ;;
+    status)
+        pid=$(collector_pid)
+        if [ -n "${pid}" ]; then
+            echo "djigger Collector (pid: ${pid}) is running"
+        else
+            echo "djigger Collector is stopped"
+        fi
+    ;;
+    restart)
+        $0 stop
+        $0 start
+    ;;
+    *)
+        echo "usage: $0 (start|stop|restart|status|help)"
+    ;;
+esac

--- a/distribution/template/contrib/djigger-collector.service
+++ b/distribution/template/contrib/djigger-collector.service
@@ -1,0 +1,18 @@
+# /etc/systemd/system/djigger-collector.service
+
+[Unit]
+Description=Denkbar djigger Collector
+After=network.target mongod.service
+Requires=mongod.service
+
+[Service]
+User=djigger
+Group=djigger
+#Environment=JAVA_HOME=/usr/lib/jvm/java
+ExecStart=/opt/denkbar/djigger/bin/startCollector.sh
+SuccessExitStatus=143
+Restart=on-failure
+RestartSec=5s
+
+[Install]
+WantedBy=multi-user.target

--- a/distribution/template/contrib/djigger-collector.sysconfig
+++ b/distribution/template/contrib/djigger-collector.sysconfig
@@ -15,4 +15,4 @@ DJIGGER_OUTFILE="${DJIGGER_HOME}/log/collector.out"
 #JAVA_HOME=/usr/lib/jvm/java-1.8.0-openjdk.x86_64
 
 # Custom startup arguments
-#JAVA_ARGS=""
+#JAVA_OPTS=""

--- a/distribution/template/contrib/djigger-collector.sysconfig
+++ b/distribution/template/contrib/djigger-collector.sysconfig
@@ -1,0 +1,18 @@
+# /etc/sysconfig/djigger-collector
+#
+# Modify these options if you want to change the way the collector daemon runs
+
+# User account which is used to run the collector process
+DJIGGER_USER=djigger
+
+# Djigger installation directory
+DJIGGER_HOME=/opt/denkbar/djigger
+
+# Where to write collector stdout/stderr. Set this to /dev/null to disable output.
+DJIGGER_OUTFILE="${DJIGGER_HOME}/log/collector.out"
+
+# Custom JVM home
+#JAVA_HOME=/usr/lib/jvm/java-1.8.0-openjdk.x86_64
+
+# Custom startup arguments
+#JAVA_ARGS=""


### PR DESCRIPTION
This PR adds the necessary scripts and configuration files as well as a description to setup autostart for the djigger collector during system boot on Linux.

This PR depends on #92 for the correct handling of the environment variables.

The scripts are tested so far on RHEL 6 (sysv-init) and Fedora 25 (systemd). You you have some other Linux distributions where you want to make sure that it works out of the box, please let me know. 

I'll still improve the documentation a bit, as the description so far is mainly for a production setup. There exist some cool systemd tricks for a developer setup that I still want to add.