### PR TITLE
Better collector status pages

### DIFF
--- a/client-ui/src/main/java/io/djigger/ui/Session.java
+++ b/client-ui/src/main/java/io/djigger/ui/Session.java
@@ -219,25 +219,25 @@ public class Session extends JPanel implements FacadeListener, Closeable {
         if (config.getType() == SessionType.AGENT) {
             final Properties prop = new Properties();
             if (config.getParameters().containsKey(SessionParameter.PROCESSID)) {
-                prop.put(ProcessAttachFacade.PROCESSID, config.getParameters().get(SessionParameter.PROCESSID));
+                prop.put(Facade.Parameters.PROCESS_ID, config.getParameters().get(SessionParameter.PROCESSID));
                 facade = new ProcessAttachFacade(prop, false);
             } else {
-                prop.put("host", config.getParameters().get(SessionParameter.HOSTNAME));
-                prop.put("port", config.getParameters().get(SessionParameter.PORT));
+                prop.put(Facade.Parameters.HOST, config.getParameters().get(SessionParameter.HOSTNAME));
+                prop.put(Facade.Parameters.PORT, config.getParameters().get(SessionParameter.PORT));
                 facade = new AgentFacade(prop, false);
             }
         } else if (config.getType() == SessionType.FILE) {
             Properties prop = new Properties();
-            prop.put(JstackLogTailFacade.FILE_PARAM, config.getParameters().get(SessionParameter.FILE));
-            prop.put(JstackLogTailFacade.START_AT_FILE_BEGIN_PARAM, "true");
+            prop.put(Facade.Parameters.FILE, config.getParameters().get(SessionParameter.FILE));
+            prop.put(Facade.Parameters.START_AT_FILE_BEGIN, "true");
 
             facade = new JstackLogTailFacade(prop, false);
         } else if (config.getType() == SessionType.JMX) {
             Properties prop = new Properties();
-            prop.put("host", config.getParameters().get(SessionParameter.HOSTNAME));
-            prop.put("port", config.getParameters().get(SessionParameter.PORT));
-            prop.put("username", config.getParameters().get(SessionParameter.USERNAME));
-            prop.put("password", config.getParameters().get(SessionParameter.PASSWORD));
+            prop.put(Facade.Parameters.HOST, config.getParameters().get(SessionParameter.HOSTNAME));
+            prop.put(Facade.Parameters.PORT, config.getParameters().get(SessionParameter.PORT));
+            prop.put(Facade.Parameters.USERNAME, config.getParameters().get(SessionParameter.USERNAME));
+            prop.put(Facade.Parameters.PASSWORD, config.getParameters().get(SessionParameter.PASSWORD));
             facade = new JMXClientFacade(prop, false);
         } else {
             facade = null;

--- a/client/src/main/java/io/djigger/client/AgentFacade.java
+++ b/client/src/main/java/io/djigger/client/AgentFacade.java
@@ -127,8 +127,8 @@ public class AgentFacade extends Facade implements MessageListener {
 
     @Override
     public void connect_() throws Exception {
-        String host = properties.getProperty("host");
-        String port = properties.getProperty("port");
+        String host = properties.getProperty(Parameters.HOST);
+        String port = properties.getProperty(Parameters.PORT);
         this.client = new MessageRouter(host, Integer.parseInt(port));
 
         startClient();

--- a/client/src/main/java/io/djigger/client/Facade.java
+++ b/client/src/main/java/io/djigger/client/Facade.java
@@ -30,6 +30,61 @@ import java.util.concurrent.atomic.AtomicInteger;
 
 public abstract class Facade {
 
+    public static class Parameters {
+        // used by JStackLogTailFacade
+        public static final String FILE = "file";
+        public static final String START_AT_FILE_BEGIN = "startAtFileBegin";
+
+        // used by ProcessAttachFacade
+        public static final String PROCESS_ID = "processID";
+        public static final String PROCESS_NAME_PATTERN = "processNamePattern";
+        public static final String CONNECTION_TIMEOUT = "connectionTimeoutMs";
+
+        // used by AgentFacade and JMXClientFacade
+        public static final String HOST = "host";
+        public static final String PORT = "port";
+
+        // used by JMXClientFacade
+        public static final String USERNAME = "username";
+        public static final String PASSWORD = "password";
+
+        /*
+         Defines the order in which the parameters should be shown when listed.
+         This is relevant for the collector status page, to guarantee a consistent and
+         logical order, e.g: host, port, username, password. This, in turn, also makes
+         the sort capabilities on the web page more useful.
+
+         The comparator also accepts values not contained in the list of known parameter
+         names. They will be sorted in alphabetical order, after the known ones.
+        */
+        public static final Comparator<String> SORT_COMPARATOR = new Comparator<String>() {
+            private final List<String> knownParamsOrder = Arrays.asList(
+                FILE, START_AT_FILE_BEGIN,
+                PROCESS_ID, PROCESS_NAME_PATTERN, CONNECTION_TIMEOUT,
+                HOST, PORT, USERNAME, PASSWORD
+            );
+
+            @Override
+            public int compare(String s1, String s2) {
+                int i1 = knownParamsOrder.indexOf(s1);
+                int i2 = knownParamsOrder.indexOf(s2);
+
+                if (i1 >= 0 && i2 >= 0) {
+                    // both are known: compare by index in knownParamsOrder
+                    return Integer.compare(i1, i2);
+                } else if (i1 < 0 && i2 < 0) {
+                    // both are unknown: compare by name
+                    return s1.compareToIgnoreCase(s2);
+                } else {
+                    // exactly one is known (>=0), and one is unknown (<0).
+                    // put the known one first, which is equivalent to a reverse integer sort
+                    return -Integer.compare(i1, i2);
+                }
+            }
+        };
+
+    }
+
     private static final Logger logger = LoggerFactory.getLogger(Facade.class);
 
     private long runtimeID;

--- a/client/src/main/java/io/djigger/client/JMXClientFacade.java
+++ b/client/src/main/java/io/djigger/client/JMXClientFacade.java
@@ -136,10 +136,10 @@ public class JMXClientFacade extends Facade implements NotificationListener {
 
     @Override
     protected synchronized void connect_() throws Exception {
-        String host = properties.getProperty("host");
-        String port = properties.getProperty("port");
-        String username = properties.getProperty("username");
-        String password = properties.getProperty("password");
+        String host = properties.getProperty(Parameters.HOST);
+        String port = properties.getProperty(Parameters.PORT);
+        String username = properties.getProperty(Parameters.USERNAME);
+        String password = properties.getProperty(Parameters.PASSWORD);
 
         logger.info("Creating JMX connection to " + host + ":" + port);
 

--- a/client/src/main/java/io/djigger/client/JstackLogTailFacade.java
+++ b/client/src/main/java/io/djigger/client/JstackLogTailFacade.java
@@ -37,20 +37,16 @@ public class JstackLogTailFacade extends Facade {
 
     private LogTailer logTailer;
 
-    public static final String FILE_PARAM = "file";
-
-    public static final String START_AT_FILE_BEGIN_PARAM = "startAtFileBegin";
-
     public JstackLogTailFacade(Properties properties, boolean autoReconnect) {
         super(properties, autoReconnect);
     }
 
-    private Object lock = new Object();
+    private final Object lock = new Object();
 
     @Override
     protected void connect_() throws Exception {
 
-        String fileParam = properties.getProperty(FILE_PARAM);
+        String fileParam = properties.getProperty(Parameters.FILE);
         if (fileParam != null) {
             final List<ThreadInfo> threadInfos = new ArrayList<>(1);
             final Parser parser = new Parser(Format.STANDARD_OUTPUT, new ParserEventListener() {
@@ -64,7 +60,7 @@ public class JstackLogTailFacade extends Facade {
                 }
             });
 
-            boolean startAtFileBegin = Boolean.parseBoolean(properties.getProperty(START_AT_FILE_BEGIN_PARAM, "false"));
+            boolean startAtFileBegin = Boolean.parseBoolean(properties.getProperty(Parameters.START_AT_FILE_BEGIN, "false"));
 
             File file = new File(fileParam);
             logTailer = new LogTailer(file, startAtFileBegin, new LogTailerListener() {
@@ -91,7 +87,7 @@ public class JstackLogTailFacade extends Facade {
                 }
             }
         } else {
-            throw new RuntimeException("File not specified. Please specify the file to be read by setting the parameter '" + FILE_PARAM + "'");
+            throw new RuntimeException("File not specified. Please specify the file to be read by setting the parameter '" + Parameters.FILE + "'");
         }
     }
 

--- a/client/src/main/java/io/djigger/client/ProcessAttachFacade.java
+++ b/client/src/main/java/io/djigger/client/ProcessAttachFacade.java
@@ -23,12 +23,6 @@ public class ProcessAttachFacade extends AgentFacade {
 
     private static final Logger logger = LoggerFactory.getLogger(ProcessAttachFacade.class);
 
-    public static final String CONNECTION_TIMEOUT = "ConnectionTimeoutMs";
-
-    public static final String PROCESSID = "processID";
-
-    public static final String PROCESS_NAME_REGEX = "processNamePattern";
-
     private static final String DEFAULT_CONNECTION_TIMEOUT = "10000";
 
     public ProcessAttachFacade(Properties properties, boolean autoReconnect) {
@@ -65,7 +59,7 @@ public class ProcessAttachFacade extends AgentFacade {
         }).start();
 
         String processID = null;
-        Object processNamePattern = properties.get(PROCESS_NAME_REGEX);
+        Object processNamePattern = properties.get(Parameters.PROCESS_NAME_PATTERN);
         if (processNamePattern != null) {
             Pattern pattern = Pattern.compile(processNamePattern.toString());
             for (VirtualMachineDescriptor vm_ : VirtualMachine.list()) {
@@ -78,7 +72,7 @@ public class ProcessAttachFacade extends AgentFacade {
                 throw new RuntimeException("No VM found matching pattern " + processNamePattern);
             }
         } else {
-            processID = properties.get(PROCESSID).toString();
+            processID = properties.get(Parameters.PROCESS_ID).toString();
         }
         vm = VirtualMachine.attach(processID);
 
@@ -101,7 +95,7 @@ public class ProcessAttachFacade extends AgentFacade {
 
         vm.loadAgent(agentJar.getAbsolutePath(), "host:" + Inet4Address.getLocalHost().getHostName() + ",port:" + port);
 
-        long timeout = Long.parseLong(properties.getProperty(CONNECTION_TIMEOUT, DEFAULT_CONNECTION_TIMEOUT));
+        long timeout = Long.parseLong(properties.getProperty(Parameters.CONNECTION_TIMEOUT, DEFAULT_CONNECTION_TIMEOUT));
         synchronized (this) {
             wait(timeout);
         }

--- a/collector/src/main/java/io/djigger/collector/server/conf/Configurator.java
+++ b/collector/src/main/java/io/djigger/collector/server/conf/Configurator.java
@@ -28,6 +28,7 @@ package io.djigger.collector.server.conf;
 import com.fasterxml.jackson.databind.JavaType;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.thoughtworks.xstream.XStream;
+import io.djigger.client.Facade;
 import io.djigger.client.JMXClientFacade;
 import io.djigger.collector.server.conf.mixin.InstrumentSubscriptionMixin;
 import io.djigger.monitoring.java.instrumentation.InstrumentSubscription;
@@ -219,10 +220,10 @@ public class Configurator {
 
         // JMX Connection Properties
         Properties connectionProperties = new Properties();
-        connectionProperties.setProperty("host", splitLine[0]);
-        connectionProperties.setProperty("port", splitLine[1]);
-        connectionProperties.setProperty("username", splitLine[2]);
-        connectionProperties.setProperty("password", resolvePasswordFromPath(splitLine[3]));
+        connectionProperties.setProperty(Facade.Parameters.HOST, splitLine[0]);
+        connectionProperties.setProperty(Facade.Parameters.PORT, splitLine[1]);
+        connectionProperties.setProperty(Facade.Parameters.USERNAME, splitLine[2]);
+        connectionProperties.setProperty(Facade.Parameters.PASSWORD, resolvePasswordFromPath(splitLine[3]));
 
         //connectionProperties.setProperty(arg0, arg1)
 

--- a/collector/src/main/java/io/djigger/collector/server/conf/Connection.java
+++ b/collector/src/main/java/io/djigger/collector/server/conf/Connection.java
@@ -20,6 +20,7 @@
 package io.djigger.collector.server.conf;
 
 import com.thoughtworks.xstream.annotations.XStreamAsAttribute;
+import io.djigger.client.Facade;
 import io.djigger.client.mbeans.MetricCollectionConfiguration;
 import io.djigger.monitoring.java.instrumentation.InstrumentSubscription;
 
@@ -97,7 +98,7 @@ public class Connection implements ConnectionGroupNode {
 
     public String toString() {
         Properties hiddenPassword = ((Properties) connectionProperties.clone());
-        hiddenPassword.setProperty("password", "***");
+        hiddenPassword.setProperty(Facade.Parameters.PASSWORD, "***");
         return connectionClass + ";" +
             hiddenPassword + ";" +
             samplingParameters.toString() + ";" +

--- a/collector/src/main/java/io/djigger/collector/server/services/ServiceServer.java
+++ b/collector/src/main/java/io/djigger/collector/server/services/ServiceServer.java
@@ -65,17 +65,22 @@ public class ServiceServer {
         ServletContainer servletContainer = new ServletContainer(resourceConfig);
         ServletHolder sh = new ServletHolder(servletContainer);
         Server server = new Server(serverPort);
-        ServletContextHandler context = new ServletContextHandler(ServletContextHandler.SESSIONS);
-        context.setContextPath("/rest");
-        context.addServlet(sh, "/*");
 
-        WebAppContext bb = new WebAppContext();
-        bb.setServer(server);
-        bb.setContextPath("/djigger");
-        bb.setResourceBase(Resource.newClassPathResource("webapp").getURI().toString());
+        ServletContextHandler restContext = new ServletContextHandler(ServletContextHandler.SESSIONS);
+        restContext.setContextPath("/rest");
+        restContext.addServlet(sh, "/*");
+
+        WebAppContext webContext = new WebAppContext();
+        webContext.setServer(server);
+        webContext.setContextPath("/djigger");
+        webContext.setResourceBase(Resource.newClassPathResource("webapp").getURI().toString());
+
+        WebAppContext rootContext = new WebAppContext();
+        rootContext.setContextPath("/");
+        rootContext.setResourceBase(Resource.newClassPathResource("webroot").getURI().toString());
 
         ContextHandlerCollection contexts = new ContextHandlerCollection();
-        contexts.setHandlers(new Handler[]{context, bb});
+        contexts.setHandlers(new Handler[]{restContext, webContext, rootContext});
         server.setHandler(contexts);
 
         return server;

--- a/collector/src/main/resources/webapp/index.html
+++ b/collector/src/main/resources/webapp/index.html
@@ -27,6 +27,7 @@ $(document).ready(function() {
 	  
 	  $('#example').DataTable( {
 			data: dataSet,
+			"lengthMenu": [ [10, 25, 50, -1], [10, 25, 50, "All"] ],
 			columns: [
 				{ title: "Connection type" },
 				{ title: "Connection properties" },

--- a/collector/src/main/resources/webroot/index.html
+++ b/collector/src/main/resources/webroot/index.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <meta http-equiv="refresh" content="0;URL=/djigger/" />
+</head>
+<body>
+If your browser doesn't automatically redirect you, please <a href="/djigger/">click here</a>.
+</body>
+</html>


### PR DESCRIPTION
Hi guys,

here's another small improvement, this time to the (HTTP) UI of the collector.

Straight from the commit log:

- consistent and logical order of properties and attributes
- show sampling rate on status page
- option to show all connections
- browser redirect from http root to actual status page (http://example.org:8080/ -> http://example.org:8080/djigger/)

As always, feel free to comment, criticize, and ask for corrections or improvements!

Thanks & cheers,
Chris