### PR TITLE
Fix XStream errors introduced with last XStream version, by whitelisting all types

### DIFF
--- a/client-ui/pom.xml
+++ b/client-ui/pom.xml
@@ -18,12 +18,6 @@
   
 	<dependencies>
 		<dependency>
-			<groupId>junit</groupId>
-			<artifactId>junit</artifactId>
-			<version>4.13.1</version>
-			<scope>test</scope>
-		</dependency>
-		<dependency>
 			<groupId>io.djigger</groupId>
 			<artifactId>commons</artifactId>
 			<version>${project.version}</version>
@@ -38,6 +32,7 @@
 			<artifactId>client</artifactId>
 			<version>${project.version}</version>
 		</dependency>
+
 		<dependency>
 			<groupId>antlr</groupId>
 			<artifactId>antlr</artifactId>
@@ -48,12 +43,6 @@
 			<artifactId>jfreechart</artifactId>
 			<version>1.0.0</version>
 		</dependency>
-		<dependency>
-			<groupId>com.thoughtworks.xstream</groupId>
-			<artifactId>xstream</artifactId>
-			<version>1.4.18</version>
-		</dependency>
-
 		<dependency>
 			<groupId>org.slf4j</groupId>
 			<artifactId>log4j-over-slf4j</artifactId>

--- a/client-ui/src/main/java/io/djigger/ui/MainFrame.java
+++ b/client-ui/src/main/java/io/djigger/ui/MainFrame.java
@@ -24,6 +24,7 @@ import io.djigger.ui.Session.SessionType;
 import io.djigger.ui.common.FileChooserHelper;
 import io.djigger.ui.common.FileMetadata;
 import io.djigger.ui.common.Settings;
+import io.djigger.xstream.XStreamFactory;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -212,7 +213,7 @@ public class MainFrame extends JPanel {
 
     private synchronized void exportSessions(File file) {
         if (file != null) {
-            XStream xstream = new XStream();
+            XStream xstream = XStreamFactory.createWithAllTypesPermission();
             List<SessionConfiguration> configs = new ArrayList<SessionConfiguration>();
             try {
                 for (Session session : sessions) {
@@ -231,7 +232,7 @@ public class MainFrame extends JPanel {
     }
 
     private void importSessionFile(File file) {
-        XStream xstream = new XStream();
+        XStream xstream = XStreamFactory.createWithAllTypesPermission();
         if (file != null) {
             String configXml;
             try {

--- a/client-ui/src/main/java/io/djigger/ui/instrumentation/SubscriptionPane.java
+++ b/client-ui/src/main/java/io/djigger/ui/instrumentation/SubscriptionPane.java
@@ -47,6 +47,7 @@ import javax.swing.event.ListSelectionListener;
 import javax.swing.table.DefaultTableModel;
 import javax.swing.table.TableCellRenderer;
 
+import io.djigger.xstream.XStreamFactory;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -135,7 +136,7 @@ public class SubscriptionPane extends Dashlet {
         commandPanel.add(new CommandButton("importConfig.png", "Import subscriptions", new Runnable() {
             @Override
             public void run() {
-                XStream xstream = new XStream();
+                XStream xstream = XStreamFactory.createWithAllTypesPermission();
                 File file = FileChooserHelper.loadFile(FileMetadata.SUBSCRIPTIONS);
                 if (file != null) {
                     Object o = xstream.fromXML(file);
@@ -151,7 +152,7 @@ public class SubscriptionPane extends Dashlet {
         commandPanel.add(new CommandButton("save.png", "Export subscriptions", new Runnable() {
             @Override
             public void run() {
-                XStream xstream = new XStream();
+                XStream xstream = XStreamFactory.createWithAllTypesPermission();
                 File file = FileChooserHelper.saveFile(FileMetadata.SUBSCRIPTIONS);
                 if (file != null) {
                     try {

--- a/collector/pom.xml
+++ b/collector/pom.xml
@@ -54,11 +54,6 @@
 			<version>${project.version}</version>
 		</dependency>
 		<dependency>
-			<groupId>com.thoughtworks.xstream</groupId>
-			<artifactId>xstream</artifactId>
-			<version>1.4.18</version>
-		</dependency>
-		<dependency>
 			<groupId>org.slf4j</groupId>
 			<artifactId>slf4j-api</artifactId>
 			<version>1.7.5</version>

--- a/collector/src/main/java/io/djigger/collector/server/conf/Configurator.java
+++ b/collector/src/main/java/io/djigger/collector/server/conf/Configurator.java
@@ -35,6 +35,7 @@ import io.djigger.collector.server.conf.mixin.InstrumentSubscriptionMixin;
 import io.djigger.monitoring.java.instrumentation.InstrumentSubscription;
 import io.djigger.monitoring.java.mbeans.MBeanCollectorConfiguration;
 
+import io.djigger.xstream.XStreamFactory;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -54,7 +55,7 @@ public class Configurator {
             throw new Exception("Invalid collector config file : " + collConfigFilename + ". Check your -DcollectorConfig option.");
 
         try {
-            XStream xstream = new XStream();
+            XStream xstream = XStreamFactory.createWithAllTypesPermission();
             xstream.alias("Collector", CollectorConfig.class);
             xstream.processAnnotations(MongoDBParameters.class);
             return (CollectorConfig) xstream.fromXML(new File(collConfigFilename));
@@ -175,7 +176,7 @@ public class Configurator {
         ConnectionsConfig cc = new ConnectionsConfig();
 
         try {
-            XStream xstream = new XStream();
+            XStream xstream = XStreamFactory.createWithAllTypesPermission();
             // [dcransac] Only Connections / Groups
             xstream.alias("Group", ConnectionGroup.class);
             xstream.alias("Connection", Connection.class);
@@ -219,7 +220,7 @@ public class Configurator {
     
     private static List<InstrumentSubscription> parseSubscriptionsXML(String subscriptionsConfigFilename) {
         try {
-            XStream xstream = new XStream();
+            XStream xstream = XStreamFactory.createWithAllTypesPermission();
             // [dcransac] Only Connections / Groups
             //xstream.alias("Group", ConnectionGroup.class);
             xstream.alias("subscriptions", List.class);

--- a/commons/pom.xml
+++ b/commons/pom.xml
@@ -45,11 +45,15 @@
 			<artifactId>antlr4-runtime</artifactId>
 			<version>4.5.3</version>
 		</dependency>
-
 		<dependency>
 			<groupId>org.slf4j</groupId>
 			<artifactId>slf4j-api</artifactId>
 			<version>1.7.5</version>
+		</dependency>
+		<dependency>
+			<groupId>com.thoughtworks.xstream</groupId>
+			<artifactId>xstream</artifactId>
+			<version>1.4.18</version>
 		</dependency>
 	</dependencies>
 </project>

--- a/commons/src/main/java/io/djigger/xstream/XStreamFactory.java
+++ b/commons/src/main/java/io/djigger/xstream/XStreamFactory.java
@@ -1,0 +1,12 @@
+package io.djigger.xstream;
+
+import com.thoughtworks.xstream.XStream;
+import com.thoughtworks.xstream.security.AnyTypePermission;
+
+public class XStreamFactory {
+    public static XStream createWithAllTypesPermission() {
+        XStream xstream = new XStream();
+        xstream.addPermission(AnyTypePermission.ANY);
+        return xstream;
+    }
+}

--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -77,6 +77,11 @@
 			</plugin>
 			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>
+				<artifactId>maven-surefire-plugin</artifactId>
+				<version>3.0.0-M3</version>
+			</plugin>
+			<plugin>
+				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-compiler-plugin</artifactId>
 				<version>3.8.0</version>
 				<configuration>


### PR DESCRIPTION
Plus some minor cleanup in the .pom files.

For completeness: There actually were unit tests (`ConfigurationTests.java` in the `collector` project) which would have failed due to the previous XStream version change, but they were not executed by maven because the surefire plugin did not consider the test file for naming reasons:

https://maven.apache.org/plugins-archives/maven-surefire-plugin-2.12.4/examples/inclusion-exclusion.html -- note that `*Tests.java` is **not** matched in that version. That's why I also specified an explicit (newer) version for surefire which will include and run these unit tests.